### PR TITLE
Fixed multiple usage-specific issues

### DIFF
--- a/lib/processFile.js
+++ b/lib/processFile.js
@@ -182,9 +182,10 @@ module.exports = function processFile(orig_fn, file_data, cb){
 
     // Create a string formatted for an anchor link
     var anchor_link = section.header
-      .replace(/\s/g, '-')
-      .replace(/[\.\/\\\?\!\@\#\_\+\=\*\(\)\^\%\$]/g, '')
-      .toLowerCase();
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '-')
+      .replace(/\-{2,}/g, '-')
+      .replace(/^\-|\-$/, '');
 
     // Set header to formatted anchor link
     section.anchor_header =
@@ -197,9 +198,10 @@ module.exports = function processFile(orig_fn, file_data, cb){
 
       // Create a string formatted for an anchor link
       var sub_anchor_link = sub.header
-        .replace(/\s/g, '-')
-        .replace(/[\.\/\\\?\!\@\#\_\+\=\*\(\)\^\%\$]/g, '')
-        .toLowerCase();
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '-')
+        .replace(/\-{2,}/g, '-')
+        .replace(/^\-|\-$/, '');
 
       // Re-add correct indentation with spaces
       var indentation = ''

--- a/lib/processFile.js
+++ b/lib/processFile.js
@@ -154,7 +154,7 @@ module.exports = function processFile(orig_fn, file_data, cb){
   sections.forEach(function (section){
 
     // Remove `* ` from header
-    section.header = section.header.replace(/\*\s/, '');
+    section.header = section.header.replace(/[\-\*\+]\s/, '');
 
     section.subs.forEach(function (sub, i){
 


### PR DESCRIPTION
Ma only accounted for root headers being prefixed with asterixes, while dashes or plusses are fine in every other location. The special character handling in the URL generator also didn't work for me, not even after this afternoon's update.
